### PR TITLE
Fix: Cogs with different extent and overviews

### DIFF
--- a/mucog.go
+++ b/mucog.go
@@ -1015,13 +1015,15 @@ func (d datas) Tiles(iterators []*Iterators) chan tile {
 						for it[3].Init(indices); it[3].Next(); {
 							x, y := DecodePair(*indices[IDX_TILE])
 							p := uint64(*indices[IDX_PLANE])
-							for _, ifd := range d[*indices[IDX_IMAGE]][*indices[IDX_LEVEL]] {
-								if uint64(x) >= ifd.minx && uint64(x) < ifd.maxx && uint64(y) >= ifd.miny && uint64(y) < ifd.maxy {
-									ch <- tile{
-										ifd:   ifd,
-										x:     uint64(x),
-										y:     uint64(y),
-										plane: p,
+							if *indices[IDX_LEVEL] < len(d[*indices[IDX_IMAGE]]) {
+								for _, ifd := range d[*indices[IDX_IMAGE]][*indices[IDX_LEVEL]] {
+									if uint64(x) >= ifd.minx && uint64(x) < ifd.maxx && uint64(y) >= ifd.miny && uint64(y) < ifd.maxy {
+										ch <- tile{
+											ifd:   ifd,
+											x:     uint64(x) - ifd.minx,
+											y:     uint64(y) - ifd.miny,
+											plane: p,
+										}
 									}
 								}
 							}

--- a/mucog_test.go
+++ b/mucog_test.go
@@ -22,7 +22,7 @@ var (
 	subdir2 = []uint8{5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6}
 )
 
-func generateData(fname string, vals [][]byte) error {
+func generateData(fname string, vals [][]byte, offset [2]float64) error {
 	bs := 64
 	ds, err := godal.Create(godal.GTiff, fname, 1, godal.Byte, bs*len(vals), bs*len(vals[0]), godal.CreationOption(
 		"TILED=YES", fmt.Sprintf("BLOCKXSIZE=%d", bs), fmt.Sprintf("BLOCKYSIZE=%d", bs),
@@ -30,7 +30,7 @@ func generateData(fname string, vals [][]byte) error {
 	if err != nil {
 		return err
 	}
-	if err = ds.SetGeoTransform([6]float64{0, 0.001, 0, 0, 0, -0.001}); err != nil {
+	if err = ds.SetGeoTransform([6]float64{offset[0] * float64(bs), 1, 0, offset[1] * float64(bs), 0, -1}); err != nil {
 		return err
 	}
 	sr, err := godal.NewSpatialRefFromEPSG(4326)
@@ -221,10 +221,10 @@ func TestMucog(t *testing.T) {
 		file2.Close()
 	}()
 
-	if err := generateData(filePath1, [][]byte{{1, 2}, {4, 5}}); err != nil {
+	if err := generateData(filePath1, [][]byte{{1, 2}, {4, 5}}, [2]float64{1, 1}); err != nil {
 		t.Errorf("TestMucog.generateData: %v", err)
 	}
-	if err := generateData(filePath2, [][]byte{{5, 6, 3}, {7, 8, 6}}); err != nil {
+	if err := generateData(filePath2, [][]byte{{5, 6, 7, 8}, {7, 8, 9, 10}}, [2]float64{0, 0}); err != nil {
 		t.Errorf("TestMucog.generateData: %v", err)
 	}
 


### PR DESCRIPTION
Crash if cogs have different extent, number of overviews or positive y-scale